### PR TITLE
Fix TypeError in line 8 in 2019/Inctf/Crypto/Single Byte/xor.py

### DIFF
--- a/2019/Inctf/Crypto/Single Byte/xor.py
+++ b/2019/Inctf/Crypto/Single Byte/xor.py
@@ -5,7 +5,7 @@ str1 = binascii.unhexlify(input_string)
 
 
 fl=''
-for i in str1:
+for i in str1.decode():
 	fl+=chr(ord(i)^ord('z'))
 
 


### PR DESCRIPTION
@naveenselvan @AkashM398 
TypeError: ord() expected string of length 1, but int found this error occured because contents of str1 was like b'\x13\x14\x19\x0e\x1c\x10\x01\x02J\x08%\x19N\x14]\x0e%\x18I%\x1fN\t\x13\x16\x03%\x18\x08J\x11I\x14\x07' 

currently fixed issue by replacing str1 with str1.decode()